### PR TITLE
Refactor: Change Function from Default to Named Export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "road2crypto-wallet-address-validator",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "A simple utility to validate cryptocurrency wallet addresses for EVM, Solana, and Bitcoin chains.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "road2crypto-wallet-address-validator",
-    "version": "1.2.0",
+    "version": "1.1.1",
     "description": "A simple utility to validate cryptocurrency wallet addresses for EVM, Solana, and Bitcoin chains.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { getWalletType } from "./utils/getWalletType";
 import { Response, ValidationErrorMessage } from "./types/response";
 
 // Function to check crypto address
-const isWalletValid = (address: string): Response => {
+export const isWalletValid = (address: string): Response => {
     // Remove extra spaces
     address = address.trim();
 
@@ -17,5 +17,3 @@ const isWalletValid = (address: string): Response => {
     // Return success response
     return { valid: true, type: walletAddressType };
 };
-
-export default isWalletValid;


### PR DESCRIPTION
The target function `isWalletValid`, which was previously exported as the default, is now exported as a named export.