### PR TITLE
fix: correct XRP validation rules from PR #66

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 
 # Ignore build output directories
 dist/
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ interface ValidationOptions {
 | Sui      | Sui addresses (Hex `0x...`, approx 66 chars)                                       | `0x1a052c15a0c3241b1842b1096053f0b2a8d3ccdd5a747926b471e956bc1b38f8` |
 | Aptos    | Aptos addresses (Hex `0x...`, approx 66 chars)                                     | `0x83e24403164007f3544d03e92e5e1e76b1f236e7a63d91f24d9c4912e75e927c` |
 | TON      | TON addresses (Base64-like `E...`/`U...`/`k...`/`0...` 48 chars)                   | `EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8GB0aH`                   |
-| XRP      | XRP classic addresses (`r...`, 25-35 chars) and X-addresses (`X...`, 46 chars)     | `rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh`                                 |
+| XRP      | XRP classic addresses (`r...`, 25-35 chars) and X-addresses (`X...`/`T...`, 47 chars) | `rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh`                                 |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ enum WalletType {
   BITCOIN = "bitcoin",
   COSMOS = "cosmos",
   TRON = "tron",
+  XRP = "xrp",
 }
 ```
 
@@ -231,6 +232,7 @@ interface ValidationOptions {
 | Sui      | Sui addresses (Hex `0x...`, approx 66 chars)                                       | `0x1a052c15a0c3241b1842b1096053f0b2a8d3ccdd5a747926b471e956bc1b38f8` |
 | Aptos    | Aptos addresses (Hex `0x...`, approx 66 chars)                                     | `0x83e24403164007f3544d03e92e5e1e76b1f236e7a63d91f24d9c4912e75e927c` |
 | TON      | TON addresses (Base64-like `E...`/`U...`/`k...`/`0...` 48 chars)                   | `EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8GB0aH`                   |
+| XRP      | XRP classic addresses (`r...`, 25-35 chars) and X-addresses (`X...`, 46 chars)     | `rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh`                                 |
 
 ## Contributing
 

--- a/src/core/classifier.ts
+++ b/src/core/classifier.ts
@@ -11,6 +11,7 @@ import { testDogecoin } from "../validators/dogecoin";
 import { testSui } from "../validators/sui";
 import { testAptos } from "../validators/aptos";
 import { testTon } from "../validators/ton";
+import { testXrp } from "../validators/xrp";
 
 // Function to get wallet address type
 export const getWalletAddressType = (address: string, chains?: WalletType[]): WalletType | null => {
@@ -67,6 +68,10 @@ export const getWalletAddressType = (address: string, chains?: WalletType[]): Wa
 
     if (isChainAllowed(WalletType.TON) && testTon().test(address)) {
         return WalletType.TON
+    }
+
+    if (isChainAllowed(WalletType.XRP) && testXrp().test(address)) {
+        return WalletType.XRP
     }
 
     return null

--- a/src/core/classifier.ts
+++ b/src/core/classifier.ts
@@ -11,7 +11,7 @@ import { testDogecoin } from "../validators/dogecoin";
 import { testSui } from "../validators/sui";
 import { testAptos } from "../validators/aptos";
 import { testTon } from "../validators/ton";
-import { testXrp } from "../validators/xrp";
+import { isValidXrp } from "../validators/xrp";
 
 // Function to get wallet address type
 export const getWalletAddressType = (address: string, chains?: WalletType[]): WalletType | null => {
@@ -70,7 +70,7 @@ export const getWalletAddressType = (address: string, chains?: WalletType[]): Wa
         return WalletType.TON
     }
 
-    if (isChainAllowed(WalletType.XRP) && testXrp().test(address)) {
+    if (isChainAllowed(WalletType.XRP) && isValidXrp(address)) {
         return WalletType.XRP
     }
 

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -12,4 +12,5 @@ export enum WalletType {
     SUI = 'sui',
     APTOS = 'aptos',
     TON = 'ton',
+    XRP = 'xrp',
 }

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -1,29 +1,36 @@
-
 // Base58 utilities (Bitcoin alphabet)
 const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-const BASE58_INDEX: Record<string, number> = {};
-for (let i = 0; i < BASE58_ALPHABET.length; i++) {
-    const ch = BASE58_ALPHABET.charAt(i);
-    BASE58_INDEX[ch] = i;
+const XRP_BASE58_ALPHABET = 'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz';
+
+function createBase58Index(alphabet: string): Record<string, number> {
+    const index: Record<string, number> = {};
+    for (let i = 0; i < alphabet.length; i++) {
+        const ch = alphabet.charAt(i);
+        index[ch] = i;
+    }
+    return index;
 }
+
+const BASE58_INDEX = createBase58Index(BASE58_ALPHABET);
+const XRP_BASE58_INDEX = createBase58Index(XRP_BASE58_ALPHABET);
 
 /**
  * Decode Base58 string into bytes. Returns null for invalid characters.
  */
-export function base58Decode(input: string): Uint8Array | null {
+function decodeBase58(input: string, alphabet: string, alphabetIndex: Record<string, number>): Uint8Array | null {
     if (input.length === 0) return new Uint8Array([]);
     const base = 58;
     const base256 = 256;
 
     // Count leading zeros
     let zeros = 0;
-    while (zeros < input.length && input.charAt(zeros) === '1') zeros++;
+    while (zeros < input.length && input.charAt(zeros) === alphabet.charAt(0)) zeros++;
 
     // Convert characters to base58 digits
     const digits: number[] = [];
     for (let i = 0; i < input.length; i++) {
         const ch = input.charAt(i);
-        const v = BASE58_INDEX[ch];
+        const v = alphabetIndex[ch];
         if (v === undefined) return null;
         digits.push(v);
     }
@@ -48,4 +55,12 @@ export function base58Decode(input: string): Uint8Array | null {
     for (let i = 0; i < zeros; i++) out.push(0);
 
     return new Uint8Array(out.reverse());
+}
+
+export function base58Decode(input: string): Uint8Array | null {
+    return decodeBase58(input, BASE58_ALPHABET, BASE58_INDEX);
+}
+
+export function base58DecodeXrp(input: string): Uint8Array | null {
+    return decodeBase58(input, XRP_BASE58_ALPHABET, XRP_BASE58_INDEX);
 }

--- a/src/validators/xrp.ts
+++ b/src/validators/xrp.ts
@@ -1,5 +1,61 @@
-// XRP address validation
-// Classic addresses: start with 'r', Base58 (ripple alphabet), 25-35 chars
-// X-addresses: start with 'X', Base58 (ripple alphabet), 46 chars
-export const testXrp = (): RegExp =>
-  /^(r[1-9A-HJ-NP-Za-km-z]{24,34}|X[1-9A-HJ-NP-Za-km-z]{45})$/;
+import { doubleSha256 } from "../utils/crypto";
+import { base58DecodeXrp } from "../utils/encoding";
+
+const CLASSIC_ADDRESS_VERSION = 0x00;
+const X_ADDRESS_PAYLOAD_LENGTH = 31;
+const X_ADDRESS_MAINNET_PREFIX = Uint8Array.from([0x05, 0x44]);
+const X_ADDRESS_TESTNET_PREFIX = Uint8Array.from([0x04, 0x93]);
+
+function hasPrefix(value: Uint8Array, prefix: Uint8Array): boolean {
+    if (value.length < prefix.length) return false;
+
+    for (let i = 0; i < prefix.length; i++) {
+        if (value[i] !== prefix[i]) return false;
+    }
+
+    return true;
+}
+
+function decodeCheckedXrp(value: string): Uint8Array | null {
+    const decoded = base58DecodeXrp(value);
+    if (!decoded || decoded.length < 5) return null;
+
+    const payload = decoded.slice(0, -4);
+    const checksum = decoded.slice(-4);
+    const hash = doubleSha256(payload);
+
+    for (let i = 0; i < 4; i++) {
+        if (checksum[i] !== hash[i]) return null;
+    }
+
+    return payload;
+}
+
+export function isValidXrpClassicAddress(address: string): boolean {
+    const payload = decodeCheckedXrp(address);
+    return payload !== null && payload.length === 21 && payload[0] === CLASSIC_ADDRESS_VERSION;
+}
+
+export function isValidXrpXAddress(address: string): boolean {
+    const payload = decodeCheckedXrp(address);
+    if (!payload || payload.length !== X_ADDRESS_PAYLOAD_LENGTH) return false;
+
+    const isMainnet = hasPrefix(payload, X_ADDRESS_MAINNET_PREFIX);
+    const isTestnet = hasPrefix(payload, X_ADDRESS_TESTNET_PREFIX);
+    if (!isMainnet && !isTestnet) return false;
+
+    const flag = payload[22];
+    if (flag >= 2) return false;
+
+    if (flag === 0) {
+        for (let i = 23; i < payload.length; i++) {
+            if (payload[i] !== 0) return false;
+        }
+    }
+
+    return true;
+}
+
+export function isValidXrp(address: string): boolean {
+    return isValidXrpClassicAddress(address) || isValidXrpXAddress(address);
+}

--- a/src/validators/xrp.ts
+++ b/src/validators/xrp.ts
@@ -1,0 +1,5 @@
+// XRP address validation
+// Classic addresses: start with 'r', Base58 (ripple alphabet), 25-35 chars
+// X-addresses: start with 'X', Base58 (ripple alphabet), 46 chars
+export const testXrp = (): RegExp =>
+  /^(r[1-9A-HJ-NP-Za-km-z]{24,34}|X[1-9A-HJ-NP-Za-km-z]{45})$/;

--- a/src/validators/xrp.ts
+++ b/src/validators/xrp.ts
@@ -44,7 +44,7 @@ export function isValidXrpXAddress(address: string): boolean {
     const isTestnet = hasPrefix(payload, X_ADDRESS_TESTNET_PREFIX);
     if (!isMainnet && !isTestnet) return false;
 
-    const flag = payload[22];
+    const flag = payload[22]!;
     if (flag >= 2) return false;
 
     if (flag === 0) {

--- a/tests/xrpRegex.test.ts
+++ b/tests/xrpRegex.test.ts
@@ -1,19 +1,20 @@
 import { isWalletValid } from '../src';
 import { WalletType } from '../src/types/wallet';
-import { testXrp } from '../src/validators/xrp';
+import { isValidXrp, isValidXrpClassicAddress, isValidXrpXAddress } from '../src/validators/xrp';
 
 describe('XRP Validation', () => {
     describe('Classic addresses (r...)', () => {
         const validAddresses = [
             'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
-            'rN7n3473SaZBCG4dFL85RGwBKnDXCB6e5E',
-            'r3AdW9AhbsB4mGCNgKSNqWYnAW7WqTWD52',
-            'rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv',
+            'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59',
+            'rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY',
+            'rrrrrrrrrrrrrrrrrrrrrhoLvTp',
         ];
 
         it('should match valid XRP classic addresses', () => {
             validAddresses.forEach(addr => {
-                expect(testXrp().test(addr)).toBe(true);
+                expect(isValidXrpClassicAddress(addr)).toBe(true);
+                expect(isValidXrp(addr)).toBe(true);
             });
         });
 
@@ -28,12 +29,15 @@ describe('XRP Validation', () => {
 
     describe('X-addresses (X...)', () => {
         const validAddresses = [
-            'X7AcgcsBL4QSjdqo1hM7o1YSgQtNKr2J7tEqq5n3Nz6SLT',
+            'X7AcgcsBL6XDcUb289X4mJ8djcdyKaB5hJDWMArnXr61cqZ',
+            'XV5sbjUmgPpvXv4ixFWZ5ptAYZ6PD2qwGkhgc48zzcx6Gkr',
+            'T719a5UwUCnEs54UsxG9CJYYDhwmFCqkr7wxCcNcfZ6p5GZ',
         ];
 
         it('should match valid XRP X-addresses', () => {
             validAddresses.forEach(addr => {
-                expect(testXrp().test(addr)).toBe(true);
+                expect(isValidXrpXAddress(addr)).toBe(true);
+                expect(isValidXrp(addr)).toBe(true);
             });
         });
 
@@ -49,17 +53,19 @@ describe('XRP Validation', () => {
     describe('Invalid addresses', () => {
         const invalidAddresses = [
             '',
-            'r',                                         
-            'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyThXXXXXXX', 
+            'r',
+            'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyT1',
+            'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyThXXXXXXX',
             '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-            'rHb9CJAWyB4rj91VRWn96DkukG4bwd0yTh', 
-            'RHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',        
+            'XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXa',
+            'XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8zeUygYrCgrPh',
+            'RHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
             'not-an-address',
         ];
 
         it('should reject invalid addresses', () => {
             invalidAddresses.forEach(addr => {
-                expect(testXrp().test(addr)).toBe(false);
+                expect(isValidXrp(addr)).toBe(false);
             });
         });
     });

--- a/tests/xrpRegex.test.ts
+++ b/tests/xrpRegex.test.ts
@@ -1,0 +1,66 @@
+import { isWalletValid } from '../src';
+import { WalletType } from '../src/types/wallet';
+import { testXrp } from '../src/validators/xrp';
+
+describe('XRP Validation', () => {
+    describe('Classic addresses (r...)', () => {
+        const validAddresses = [
+            'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+            'rN7n3473SaZBCG4dFL85RGwBKnDXCB6e5E',
+            'r3AdW9AhbsB4mGCNgKSNqWYnAW7WqTWD52',
+            'rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv',
+        ];
+
+        it('should match valid XRP classic addresses', () => {
+            validAddresses.forEach(addr => {
+                expect(testXrp().test(addr)).toBe(true);
+            });
+        });
+
+        it('should validate via isWalletValid', () => {
+            validAddresses.forEach(addr => {
+                const result = isWalletValid(addr, { chains: [WalletType.XRP] });
+                expect(result.valid).toBe(true);
+                expect(result.type).toBe(WalletType.XRP);
+            });
+        });
+    });
+
+    describe('X-addresses (X...)', () => {
+        const validAddresses = [
+            'X7AcgcsBL4QSjdqo1hM7o1YSgQtNKr2J7tEqq5n3Nz6SLT',
+        ];
+
+        it('should match valid XRP X-addresses', () => {
+            validAddresses.forEach(addr => {
+                expect(testXrp().test(addr)).toBe(true);
+            });
+        });
+
+        it('should validate via isWalletValid', () => {
+            validAddresses.forEach(addr => {
+                const result = isWalletValid(addr, { chains: [WalletType.XRP] });
+                expect(result.valid).toBe(true);
+                expect(result.type).toBe(WalletType.XRP);
+            });
+        });
+    });
+
+    describe('Invalid addresses', () => {
+        const invalidAddresses = [
+            '',
+            'r',                                         
+            'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyThXXXXXXX', 
+            '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+            'rHb9CJAWyB4rj91VRWn96DkukG4bwd0yTh', 
+            'RHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',        
+            'not-an-address',
+        ];
+
+        it('should reject invalid addresses', () => {
+            invalidAddresses.forEach(addr => {
+                expect(testXrp().test(addr)).toBe(false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## What

This PR builds on top of #66 and keeps the original XRP support commit from @Kitketovsky, while fixing the validation logic to match XRPL address rules more closely.

Main changes:
- replace regex-only XRP validation with checksum-based validation
- validate classic XRP addresses using XRPL Base58Check rules
- validate X-addresses using XRPL payload and checksum rules
- support test-network X-addresses (`T...`) in addition to mainnet X-addresses
- correct the README entry for X-address length/format
- replace weak XRP tests with checksum-valid and checksum-invalid cases based on official XRPL vectors

## Why

The original PR added XRP support, but the implementation only checked the shape of the string.

That is not enough for XRP because:
- a string can match the expected prefix/length and still be an invalid XRPL address
- X-addresses include encoded payload rules beyond simple pattern matching
- the previous tests would allow false positives

This follow-up keeps the original contribution but makes the validator strict enough for production use.

## Impact

- valid XRP classic addresses still pass
- valid X-addresses now pass based on real XRPL rules instead of regex shape only
- invalid XRP strings that previously could have slipped through are now rejected
- test-network X-addresses are now recognized
- documentation is aligned with actual XRPL address behavior

## Credit

This PR intentionally builds on top of #66 so the original XRP support contribution from @Kitketovsky remains in history.

Validation was checked by:
- verifying the implemented checksum/payload logic against official XRPL valid examples
- verifying rejection of checksum-broken and malformed XRP/X-address examples
- checking the final git diff for correctness and consistency
